### PR TITLE
Fix assignment of Machine-type to a variable intended for use as str

### DIFF
--- a/wolbot.py
+++ b/wolbot.py
@@ -87,7 +87,7 @@ def cmd_wake(bot, update, **kwargs):
 
     # Parse arguments and send WoL packets
     if len(machines) == 1:
-        machine_name = machines[0]
+        machine_name = machines[0].name
     else:
         machine_name = kwargs['args'][0]
     for m in machines:


### PR DESCRIPTION
Found a bug that assigns a Machine-object to a variable that is later used as str. This lead to a runtime error because converting a Machine to str is not possible.
Please have a look, and check if you would like to take my change into your repo, thanks!