### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-telegram-bot>=10.0.0
+python-telegram-bot>=10.0.0,<12.0.0
 requests>=2.0.0


### PR DESCRIPTION
A version restriction for python-telegram-bot has been set to <12.0.0
since from version 12 the current implementation of Telegram bot does
no longer work.

See [this](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Transition-guide-to-Version-12.0) and [this](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Transition-guide-to-Version-13.0)